### PR TITLE
Oj indent assumes Fixnum whereas JSON indent assumes a String.

### DIFF
--- a/lib/rails/patch/json/encode.rb
+++ b/lib/rails/patch/json/encode.rb
@@ -26,6 +26,10 @@ module Rails::Patch::Json::Encode
     [Object, Array, FalseClass, Float, Hash, Integer, NilClass, String, TrueClass].each do |klass|
       klass.class_eval do
         def to_json(opts = {})
+          if MultiJson.adapter == MultiJson::Adapters::Oj
+            opts = opts.to_h
+            opts[:indent] = Oj.default_options[:indent]
+          end
           MultiJson::dump(self.as_json(opts), opts)
         end
       end


### PR DESCRIPTION
Without this, some of our code receives this unhandled exception:

> ArgumentError: :indent must be a Fixnum.
>     from (irb):13:in `dump'
>     from (irb):13:in`dump'
>     from /var/www/platform/shared/dashboard/bundle/ruby/2.1.0/gems/multi_json-1.9.2/lib/multi_json/adapter.rb:24:in `dump'
>     from /var/www/platform/shared/dashboard/bundle/ruby/2.1.0/gems/multi_json-1.9.2/lib/multi_json.rb:138:in`dump'
>     from (irb):66:in `to_json'
>     from /var/www/platform/shared/dashboard/bundle/ruby/2.1.0/gems/hashie-2.1.1/lib/hashie/hash.rb:30:in`to_json'
>     from /opt/rbenv/versions/2.1.2/lib/ruby/2.1.0/json/common.rb:223:in `generate'
>     from /opt/rbenv/versions/2.1.2/lib/ruby/2.1.0/json/common.rb:223:in`generate'
>     from /opt/rbenv/versions/2.1.2/lib/ruby/2.1.0/json/common.rb:394:in `dump'
